### PR TITLE
既読機能のサーバーサイド実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.33.0)
+    capybara (3.34.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -72,6 +72,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
@@ -86,7 +87,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -103,6 +104,11 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
@@ -194,7 +200,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -206,6 +212,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4)
+  pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
   sass-rails (~> 5)

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -7,3 +7,7 @@
 .post-date{
   color: gray;
 }
+
+div[data-check="true"] {
+  background: #585555;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,4 +8,16 @@ class PostsController < ApplicationController
     Post.create(content: params[:content])
     redirect_to action: :index
   end
+
+  def checked
+    post = Post.find(params[:id])
+    if post.checked 
+      post.update(checked: false)
+    else
+      post.update(checked: true)
+    end
+
+    item = Post.find(params[:id])
+    render json: { post: item }
+  end
 end

--- a/app/javascript/checked.js
+++ b/app/javascript/checked.js
@@ -1,0 +1,30 @@
+function check(){
+  const posts = document.querySelectorAll(".post");
+  posts.forEach(function (post){
+    if (post.getAttribute("data-load") != null) {
+      return null;
+    }
+    post.setAttribute("data-load", "true");
+    post.addEventListener("click",() => {
+      const postId = post.getAttribute("data-id");
+      const XHR = new XMLHttpRequest();
+      XHR.open("GET",`/posts/${postId}`,true);
+      XHR.responseType = "json";
+      XHR.send();
+      XHR.onload = () => {
+        if (XHR.status != 200) {
+          alert(`Error ${XHR.status}: ${XHR.statusText}`);
+          return null;          
+        }
+        const item = XHR.response.post;
+        if (item.checked === true) {
+          post.setAttribute("data-check", "true");
+        } else if (item.checked === false) {
+          post.removeAttribute("data-check");
+        }
+      };
+    });
+  });
+}
+setInterval(check, 1000);
+window.addEventListener("load",check);

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
 
 
 <% @posts.each do |post| %>
-    <div class="post">
+  <div class="post" data-id=<%= post.id %> data-check=<%= post.checked %>>
     <div class="post-date">
       投稿日時：<%= post.created_at %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'posts#index'
   post 'posts', to: 'posts#create'
+  get 'posts/id', to: 'posts#checked'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'posts#index'
   post 'posts', to: 'posts#create'
-  get 'posts/id', to: 'posts#checked'
+  get 'posts/:id', to: 'posts#checked'
 end


### PR DESCRIPTION
#WHAT
ルーティングの設定
レスポンスの設定

エンドポイントにアクセス
レスポンスデータをJSONが受け取る
既読のメモは薄暗く設定する

#WHY
一意の情報であったため、pathパラメーターを使用。posts/:idとすることで認識しやすくしました。
checkedアクションを定義しました。既読するidを渡せるよう、設定。条件式を使い、既読するか否か判定するプロパティを指定しアクティブレコードのupdateでデータの更新を行いました。更新したレコードをrender　jsonで返却しました。

querySelectorAllメソッドでクラス名にもつ要素の情報を取得、複数取得した要素に対しforEachで処理を行う。addEventListenerメソッドでクリック時にイベント駆動を設定。XMLHttpRequestとカスタムデータでビューファイルにidを埋め込み、取得Ajaxにリクエストを送信する。XHRオブジェクトを生成し、openメソッドでリクエストの内容を指定する。responseTypeメソッドでほしいデータ形式を指定、今回はJSON。sendメソッドでリクエストを送信。レスポンスの受信が成功した時に呼び出されるopenプロパティを設定。既読か未読されたitemはcheckedアクションにて返却か削除する。エラーが返却起きないように、レスポンスステータスの表示と条件式とする。既読時にグレーアウトするようにdiv[data-check="true"]とcssに記載。